### PR TITLE
make item text search case-insensitive, with test

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,7 +4,7 @@ class Item < ApplicationRecord
   RATINGS = ['', '?', 'Safe', 'Caution', 'NSFP'].freeze
   scope :year, ->(year = nil) { year ? where(year:) : all }
   scope :item_number, ->(number = nil) { number ? where(item_number: number) : all }
-  scope :item_text, ->(text = '') { where('original_item LIKE ?', "%#{text}%") }
+  scope :item_text, ->(text = '') { where('LOWER(original_item) LIKE ?', "%#{text}%") }
   scope :points, ->(number = nil) { number ? where(point_value: number) : all }
   scope :rating, ->(rated = 'Caution') {
     accepted_ratings_index = (RATINGS.map(&:downcase).index(rated&.downcase) || 3) + 1

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe Item, type: :model do
       expect(Item.filter_by_params({ item_text: 'shit' }).count).to be(1)
     end
 
+    it 'is not case-sensitive for item text' do
+      shit2.update(original_item: 'Huge tracts of land')
+      expect(Item.filter_by_params({ item_text: 'huge' }).count).to be(1)
+    end
+
     it 'filters by points' do
       shit2.update(point_value: 1)
       expect(Item.filter_by_params({ points: 1 }).count).to be(1)


### PR DESCRIPTION
Most users probably expect case-insensitive search, as with major search engines. It's incredibly irritating to search for, say, `elan` and get no results but find eventually that the item you wanted (2008.95) started with `Elan`. This change produces the more expected behavior.